### PR TITLE
bump version to include changes to upstream ccutrer/balboa_worldwide_app

### DIFF
--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "BWALink"
 description: "This Balboa Worldwide App Addon is interacting with Wifi spa controllers from Balboa Water Group using a serial to ip gateway."
-version: "2023.6.0"
+version: "2024.8.0"
 slug: "bwalink"
 init: false
 arch:


### PR DESCRIPTION
Rebuilding the container will fetch the newest version of balboa_worldwide_app. I'm bumping up the version to hint the need. Otherwise rebuilding the container works sufficiently.